### PR TITLE
Add ROS 2 compliance linting workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 80

--- a/.github/workflows/ros_lint.yml
+++ b/.github/workflows/ros_lint.yml
@@ -1,0 +1,24 @@
+name: ROS 2 Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ament_lint:
+    runs-on: ubuntu-latest
+    container: ros:jazzy
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install linters
+        run: |
+          apt-get update
+          apt-get install -y python3-ament-copyright python3-ament-flake8 python3-ament-pep257
+      - name: Run ament_copyright
+        run: ament_copyright src/
+      - name: Run ament_flake8
+        run: ament_flake8 src/
+      - name: Run ament_pep257
+        run: ament_pep257 src/


### PR DESCRIPTION
Added a GitHub Actions workflow to run ROS 2 compliance linters (`ament_copyright`, `ament_flake8`, `ament_pep257`) on the source code using the `ros:jazzy` container. Also added a `.flake8` configuration file to ensure `ament_flake8` respects the project's 80-character line limit.

---
*PR created automatically by Jules for task [5960676259482986527](https://jules.google.com/task/5960676259482986527) started by @riccardo-enr*